### PR TITLE
Remove extra call to toggleLE() in HW SPI mode (fixes #8)

### DIFF
--- a/src/TLC591x.cpp
+++ b/src/TLC591x.cpp
@@ -215,7 +215,6 @@ void TLC591x::write(byte n) {
   else {
     SPI.beginTransaction(SPISettings(10000000, LSBFIRST, SPI_MODE0));
     SPI.transfer(n);
-///    toggleLE();
     SPI.endTransaction();
   }
 #else  // Special code for MSP432 since it has an older version of SPI library
@@ -224,7 +223,6 @@ void TLC591x::write(byte n) {
     SPI.setClockDivider(SPI_CLOCK_DIV4);
     SPI.setDataMode(SPI_MODE0);
     SPI.transfer(n);
-///    toggleLE();
   }
 #endif
   if (OE_pin != NO_PIN && pwmMode == TLC_ENABLED ) displayBrightness(brightness);   // Switch back to previous setting

--- a/src/TLC591x.cpp
+++ b/src/TLC591x.cpp
@@ -215,7 +215,7 @@ void TLC591x::write(byte n) {
   else {
     SPI.beginTransaction(SPISettings(10000000, LSBFIRST, SPI_MODE0));
     SPI.transfer(n);
-    toggleLE();
+///    toggleLE();
     SPI.endTransaction();
   }
 #else  // Special code for MSP432 since it has an older version of SPI library
@@ -224,7 +224,7 @@ void TLC591x::write(byte n) {
     SPI.setClockDivider(SPI_CLOCK_DIV4);
     SPI.setDataMode(SPI_MODE0);
     SPI.transfer(n);
-    toggleLE();
+///    toggleLE();
   }
 #endif
   if (OE_pin != NO_PIN && pwmMode == TLC_ENABLED ) displayBrightness(brightness);   // Switch back to previous setting


### PR DESCRIPTION
Fixes #8.

When configured to use HW SPI, the code was toggling the LE line an extra time -- once after sending the data, and again right after that without any data. In some setups, this could cause some glitching with the LED segment display. 
